### PR TITLE
Add top selling date by merchant to view and added a $ sign

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -21,7 +21,7 @@ class Merchant < ApplicationRecord
     .select('invoices.created_at, sum(invoice_items.unit_price * invoice_items.quantity) as revenue')
     .group("invoices.created_at")
     .order("revenue desc", "invoices.created_at desc")
-    .first.created_at    
+    .first  
   end
 
   def self.top_five_merchants_by_revenue

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -33,7 +33,8 @@
   <h2>Top 5 Merchants by Revenue:</h2>
   <% @top_5_merchants.each do |merchant| %>
     <div id="id-<%= merchant.id %>">
-      <%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}"%> -- Total Revenue: <%= merchant.revenue %>
+      <p><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}"%> -- Total Revenue: $<%= merchant.revenue %> 
+      <p>Top selling date for <%="#{merchant.name}"%> was <%= render partial: 'admin/formatted_created_at', locals: {x: merchant} %></p>
     </div>
   <% end %>
 

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -70,6 +70,15 @@ RSpec.describe '#index' do
 
 
     it 'I see the date with the most revenue for each merchant' do
+      load_test_data
+      visit "/admin/merchants"
+      
+      within '#top-5-merchants' do
+        within "#id-#{@merchant1.id}" do
+          save_and_open_page
+          expect(page).to have_content("Top selling date for #{@merchant1.name} was Tuesday, February 28, 2023")
+        end
+      end
     end
 
   
@@ -80,7 +89,7 @@ RSpec.describe '#index' do
       within "#top-5-merchants" do
       
         expect(page).to have_content("Top 5 Merchants by Revenue")
-        expect(page).to have_content "Melissa Jenkins -- Total Revenue: 66414"
+        expect(page).to have_content "Melissa Jenkins -- Total Revenue: $66414"
         expect("Melissa Jenkins").to appear_before("Mickey Mantle")
         expect("Mickey Mantle").to appear_before("Human who sells stuff")
         expect("Human who sells stuff").to appear_before("Carlos Jenkins")

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Merchant, type: :model do
       end
 
       it 'date with the most revenue generated' do
-        expect(@merchant.best_day).to eq(@inv1.created_at)
+        expect(@merchant.best_day.created_at).to eq(@inv1.created_at)
       end
     end
 


### PR DESCRIPTION
Note that all teh best sell dates are the same.... but I don't see a created_at override in the test data so I assume its fine.

I also added a $ to conner's line.