### PR TITLE
Add figaro and github service to use the github token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 
 #Ignore coverage folder for SimpleCov
 coverage
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'jbuilder', '~> 2.5'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
+gem "figaro"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
     faker (3.1.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
+    figaro (1.2.0)
+      thor (>= 0.14.0, < 2)
     globalid (1.1.0)
       activesupport (>= 5.0)
     httparty (0.21.0)
@@ -254,6 +256,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   factory_bot_rails
   faker
+  figaro
   httparty
   jbuilder (~> 2.5)
   launchy

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -2,24 +2,30 @@ require 'httparty'
 
 class GithubService
   def contributors
-    get_url( "https://api.github.com/repos/torienyart/little-esty-shop/contributors")
+    get_url( "https://api.github.com/repos/torienyart/little-esty-shop/contributors", headers: {"Authorization" => "Bearer #{ENV['github_token']}"})
   end
 
   def commits
-    get_url("https://api.github.com/repos/torienyart/little-esty-shop/commits?author=#{username}&per_page=100")
+    get_url("https://api.github.com/repos/torienyart/little-esty-shop/commits?author=#{username}&per_page=100", headers: {"Authorization" => "Bearer #{ENV['github_token']}"})
   end
 
   def prs
-    get_url("https://api.github.com/repos/torienyart/little-esty-shop/pulls?state=closed")
+    get_url("https://api.github.com/repos/torienyart/little-esty-shop/pulls?state=closed", headers: {"Authorization" => "Bearer #{ENV['github_token']}"})
 
   end
 
   def repo
-    get_url("https://api.github.com/repos/torienyart/little-esty-shop")
+    get_url("https://api.github.com/repos/torienyart/little-esty-shop", headers: {"Authorization" => "Bearer #{ENV['github_token']}"})
   end
 
-  def get_url(url) #Make a Get request
-    response = HTTParty.get(url)
+  def collaborators
+    get_url("https://api.github.com/repos/torienyart/little-esty-shop/collaborators", headers: {"Authorization" => "Bearer #{ENV['github_token']}"})
+  end
+
+  def get_url(url, token) #Make a Get request
+    response = HTTParty.get(url, token)
     parsed = JSON.parse(response.body, symbolize_names: true)
   end
 end
+
+p GithubService.new.collaborators


### PR DESCRIPTION
Note that you will need to run instructions from this repo: 
https://github.com/laserlemon/figaro

you should only need to run : `bundle exec figaro install `
and add the line: github_token: <your_token>